### PR TITLE
Fixed typo in phpdoc

### DIFF
--- a/Command/Command.php
+++ b/Command/Command.php
@@ -181,7 +181,7 @@ class Command
     }
 
     /**
-     * Initializes the command just after the input has been validated.
+     * Initializes the command before the input has been validated.
      *
      * This is mainly useful when a lot of commands extends one main command
      * where some things need to be initialized based on the input arguments and options.


### PR DESCRIPTION
I'm using the initialize() method for the first time and noticed, that input validation happens after this method, not before (see line #232 & #248)
