### PR TITLE
Support `cli.php -c value command -o option`

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -110,7 +110,7 @@ class Application
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
         if (null === $input) {
-            $input = new ArgvInput();
+            $input = new ArgvInput(null, $this->definition);
         }
 
         if (null === $output) {

--- a/Input/ArgvInput.php
+++ b/Input/ArgvInput.php
@@ -261,6 +261,10 @@ class ArgvInput extends Input
      */
     public function getFirstArgument()
     {
+        if (0 !== count($this->arguments)) {
+            return reset($this->arguments);
+        }
+
         foreach ($this->tokens as $token) {
             if ($token && '-' === $token[0]) {
                 continue;

--- a/Input/ArrayInput.php
+++ b/Input/ArrayInput.php
@@ -48,6 +48,10 @@ class ArrayInput extends Input
      */
     public function getFirstArgument()
     {
+        if (0 !== count($this->arguments)) {
+            return reset($this->arguments);
+        }
+
         foreach ($this->parameters as $key => $value) {
             if ($key && '-' === $key[0]) {
                 continue;

--- a/Tests/ApplicationTest.php
+++ b/Tests/ApplicationTest.php
@@ -1011,6 +1011,30 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $inputStream = $application->getHelperSet()->get('question')->getInputStream();
         $this->assertEquals($tester->getInput()->isInteractive(), @posix_isatty($inputStream));
     }
+
+    /**
+     * When an InputOption with VALUE_REQUIRED precedes the first argument it should not use it's value as the first argument
+     *
+     * This test will fail with 'Command "custom" is not defined' if broken
+     */
+    public function testAppendDefaultInputDefinitionWithValueRequired()
+    {
+        $application = new CustomAppendApplication();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add(new \FooCommand());
+
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $input = new ArrayInput(array('--custom' => 'custom', 'command' => 'foo:bar'), $application->getDefinition());
+        $application->run($input, $output);
+
+        $input = new ArgvInput(array('cli.php', '-c', 'custom', 'foo:bar'), $application->getDefinition());
+        $application->run($input, $output);
+
+        $input = new ArgvInput(array('cli.php', '--custom', 'custom', 'foo:bar'), $application->getDefinition());
+        $application->run($input, $output);
+    }
 }
 
 class CustomApplication extends Application
@@ -1033,6 +1057,21 @@ class CustomApplication extends Application
     protected function getDefaultHelperSet()
     {
         return new HelperSet(array(new FormatterHelper()));
+    }
+}
+
+class CustomAppendApplication extends Application
+{
+    /**
+     * Overwrites the default input definition.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    protected function getDefaultInputDefinition()
+    {
+        $defintion = parent::getDefaultInputDefinition();
+        $defintion->addOption(new InputOption('--custom', '-c', InputOption::VALUE_REQUIRED, 'Set the custom input definition.'));
+        return $defintion;
     }
 }
 


### PR DESCRIPTION
I'd like to be able to add `InputOption`s with with `VALUE_REQUIRED`  to the `Application::getDefaultInputDefinition` because for some things it's just more natural for options to precede the command (eg; `cli.php --config ~/.mycnf do_something --another option`.

However the code relies on the token being the first argument (being the command) and does not take the `InputDefinition` into consideration for this.

I'm not entirely sure if this is the right way to solve it, I don't know if the `Application::run` just takes the 2 arguments for testing purposes or if there are other reasons, when I needed to do `$application->getDefinition()` in the tests I realised that if someone would feed `Application::run` a custom `Input` they'd have to do that too, which might be odd?