### PR TITLE
allow getting of $catchExceptions

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -240,6 +240,16 @@ class Application
     }
 
     /**
+     * Gets the applications catch exceptions property.
+     *
+     * @return bool catchExceptions property
+     */
+    public function getCatchExceptions()
+    {
+        return $this->catchExceptions;
+    }
+
+    /**
      * Sets whether to catch exceptions or not during commands execution.
      *
      * @param bool $boolean Whether to catch exceptions or not during commands execution


### PR DESCRIPTION
Im working on a laravel pull request which utlises the Console\Application.

I need to set ```$catchExceptions``` to false for this, which is fine, theres a setter for it.

However ideally i should be able to save the properties current state before changing it, allowing me to restore it, which isnt currently possible as there is no getter method.

This solves that problem.