### PR TITLE
Allow the default command to be non-interactive

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -182,7 +182,9 @@ class Application
 
         if (!$name) {
             $name = $this->defaultCommand;
-            $input = new ArrayInput(array('command' => $this->defaultCommand));
+            $newInput = new ArrayInput(array('command' => $this->defaultCommand));
+            $newInput->setInteractive($input->isInteractive());
+            $input = $newInput;
         }
 
         // the command name MUST be the first element of the input


### PR DESCRIPTION
At the moment the default command receives an `$input` object with any command-line options wiped out. It should be allowed to run a default command with options... and at least with the interactivity setting passed through.
