### PR TITLE
Allow to pass the verbosity level to the --verbose long option.

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -874,7 +874,7 @@ class Application
 
             new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message'),
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
-            new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
+            new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_OPTIONAL, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
             new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
             new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),


### PR DESCRIPTION
The help text for the verbosity option mentions that it is possible to pass a value to set the verbosity level:

```
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

However, when I try this I get an error message:

```
$ php application.php demo:greet Fabien --verbose=3

  [Symfony\Component\Console\Exception\RuntimeException]  
  The "--verbose" option does not accept a value.         
```

The `-vvv` option works fine, but the POSIX long option `--verbose` doesn't accept a value. This is clearly the intention since these values are being read in `Application::configureIO()`:

```
            if ($input->hasParameterOption('-vvv', true) || $input->hasParameterOption('--verbose=3', true) || $input->getParameterOption('--verbose', false, true) === 3) {
```

The solution is to simply change the input option from `VALUE_NONE` to `VALUE_OPTIONAL`.
