### PR TITLE
Fix multiline ProgressBar erasing previous output line

### DIFF
--- a/Helper/ProgressBar.php
+++ b/Helper/ProgressBar.php
@@ -484,7 +484,7 @@ class ProgressBar
             $this->output->write("\x1B[2K");
 
             // Erase previous lines
-            if ($this->formatLineCount > 0) {
+            if ($this->step > 1 && $this->formatLineCount > 0) {
                 $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
             }
         } elseif ($this->step > 0) {


### PR DESCRIPTION
Previously, if your progress bar was multiline, its initial display would erase the line above it in the console output. This PR fixes that.
