### PR TITLE
SymfonyStyle - misssing implements instruction

### DIFF
--- a/Style/SymfonyStyle.php
+++ b/Style/SymfonyStyle.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Terminal;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class SymfonyStyle extends OutputStyle
+class SymfonyStyle extends OutputStyle implements StyleInterface
 {
     const MAX_LINE_LENGTH = 120;
 


### PR DESCRIPTION
Symfony\Component\Console\Style\StyleInterface interface was created and Symfony\Component\Console\Style\SymfonyStyle should implement it. It generally does it but it is not added to the class' declaration.