### PR TITLE
Add gitattributes to exclude files and folders from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Added `.gitattributes` to exclude the Tests folder on export - e.g. when pulled in via composer.

I've also included the following files which are also not required:

`.gitattributes`, `.gitignore`, `phpunit.xml.dist`