### PR TITLE
Fix event dispatcher dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/debug": "~2.8|~3.0",
-        "symfony/event-dispatcher": ~2.8|~3.0"
+        "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "require-dev": {
         "symfony/filesystem": "~2.8|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/debug": "~2.8|~3.0"
+        "symfony/debug": "~2.8|~3.0",
+        "symfony/event-dispatcher": ~2.8|~3.0"
     },
     "require-dev": {
-        "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/filesystem": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
         "psr/log": "~1.0"


### PR DESCRIPTION
After composer require symfony/console I get this error: 
```
Fatal error: Class 'Symfony\Component\EventDispatcher\Event' not found in /var/www/phpgraph/vendor/symfony/console/Event/ConsoleEvent.php on line 25
```
I think this should be by default because it's not optional. 