### PR TITLE
Catch exceptions from posix_isatty

### DIFF
--- a/Output/StreamOutput.php
+++ b/Output/StreamOutput.php
@@ -99,7 +99,11 @@ class StreamOutput extends Output
                 || 'ON' === getenv('ConEmuANSI')
                 || 'xterm' === getenv('TERM');
         }
-
-        return function_exists('posix_isatty') && @posix_isatty($this->stream);
+        
+        try {
+            return function_exists('posix_isatty') && @posix_isatty($this->stream);
+        } catch(\Exception $e) {
+            return false;   
+        }
     }
 }


### PR DESCRIPTION
We are converting warnings to exceptions, which appears to not take into account `@suppression`.

This try-catch block does the same job, but allows for "upgraded" warnings.