### PR TITLE
Updated console error font color

### DIFF
--- a/Formatter/OutputFormatter.php
+++ b/Formatter/OutputFormatter.php
@@ -69,7 +69,7 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $this->decorated = (bool) $decorated;
 
-        $this->setStyle('error', new OutputFormatterStyle('white', 'red'));
+        $this->setStyle('error', new OutputFormatterStyle('black', 'red'));
         $this->setStyle('info', new OutputFormatterStyle('green'));
         $this->setStyle('comment', new OutputFormatterStyle('yellow'));
         $this->setStyle('question', new OutputFormatterStyle('black', 'cyan'));


### PR DESCRIPTION
The previous white on red(ANSI) was hard to read. 

Black on red is much more pleasant to read.

**Before / After comparison**
![before-after-console-color](https://user-images.githubusercontent.com/1721611/30155676-7f2f0786-93ce-11e7-8ea8-fbd956505503.jpg)
