### PR TITLE
fix bug

### DIFF
--- a/Input/InputOption.php
+++ b/Input/InputOption.php
@@ -113,7 +113,7 @@ class InputOption
      */
     public function acceptValue()
     {
-        return $this->isValueRequired() || $this->isValueOptional();
+        return $this->isValueRequired() || $this->isValueOptional() || $this->isArray();
     }
 
     /**


### PR DESCRIPTION
desc info : 
    function : acceptValue()
    notes : return bool true if value mode is not self::VALUE_NONE, false otherwise.
    add code : ```$this->isArray()```

bug show:
    console script add code:
    ```
    $this->addOption('option9', null, 8, 'array', [1,2,3]);
    ```
    output exception:
    [Symfony\Component\Console\Exception\InvalidArgumentException]
    Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.
