### PR TITLE
change accessibility for getStepWidth to public

### DIFF
--- a/Helper/ProgressBar.php
+++ b/Helper/ProgressBar.php
@@ -172,7 +172,7 @@ final class ProgressBar
         return $this->step;
     }
 
-    private function getStepWidth(): int
+    public function getStepWidth(): int
     {
         return $this->stepWidth;
     }


### PR DESCRIPTION
In line 459 the method is used from outside (a closure that gets any object of class `ProgressBar` or a subclass of it). So the method has to be public. It's magic that it is working and not good coding style.