### PR TITLE
Improve rendering of optional arguments in command synopsis.

### DIFF
--- a/Input/InputDefinition.php
+++ b/Input/InputDefinition.php
@@ -382,21 +382,21 @@ class InputDefinition
             $elements[] = '[--]';
         }
 
+        $tail = '';
         foreach ($this->getArguments() as $argument) {
             $element = '<'.$argument->getName().'>';
-            if (!$argument->isRequired()) {
-                $element = '['.$element.']';
-            } elseif ($argument->isArray()) {
-                $element = $element.' ('.$element.')';
-            }
-
             if ($argument->isArray()) {
                 $element .= '...';
+            }
+
+            if (!$argument->isRequired()) {
+                $element = '['.$element;
+                $tail .= ']';
             }
 
             $elements[] = $element;
         }
 
-        return implode(' ', $elements);
+        return implode(' ', $elements) . $tail;
     }
 }


### PR DESCRIPTION
Current rendering:
```
  build [options] [--] [<file>] [<output-dir>] [<packages>]...
```
Fixed (and actually correct) rendering:
```
  build [options] [--] [<file> [<output-dir> [<packages>...]]]
```
Also dropped duplicating required array-type argument. There's just no need for that, it only confuses the reader.