### PR TITLE
Fix for new line race condition

### DIFF
--- a/Output/StreamOutput.php
+++ b/Output/StreamOutput.php
@@ -70,7 +70,11 @@ class StreamOutput extends Output
      */
     protected function doWrite($message, $newline)
     {
-        if (false === @fwrite($this->stream, $message) || ($newline && (false === @fwrite($this->stream, PHP_EOL)))) {
+        if ($newline) {
+            $message .= PHP_EOL;
+        }
+
+        if (false === @fwrite($this->stream, $message)) {
             // should never happen
             throw new RuntimeException('Unable to write output.');
         }


### PR DESCRIPTION
In high throughput environments writing `message` and `PHP_EOL` separately causes race condition issues, where messages might be written in order 

- message
- message
- EOL
- EOL

instead of

- message
- EOL
- message
- EOL

An example below is a laravel application queue workers handled by supervisor.

Before:
![ezgif-1-77388f9210cf](https://user-images.githubusercontent.com/2752769/46792349-bec13180-cd75-11e8-8f91-92f05762f964.gif)

After:
![ezgif-1-0b839d642644](https://user-images.githubusercontent.com/2752769/46792420-e617fe80-cd75-11e8-9414-4bfc85d9c569.gif)
