### PR TITLE
allow $newline arg to work on section->write()

### DIFF
--- a/Output/ConsoleSectionOutput.php
+++ b/Output/ConsoleSectionOutput.php
@@ -104,7 +104,7 @@ class ConsoleSectionOutput extends StreamOutput
 
         $this->addContent($message);
 
-        parent::doWrite($message, true);
+        parent::doWrite($message, $newLine);
         parent::doWrite($erasedContent, false);
     }
 


### PR DESCRIPTION
fix `$output->section()->write()` without newline output

by default, it is impossible to use write without newline when using a `ConsoleSectionOutput` as consoleOutput (including with `SymfonyStyle` : `$io = new SymfonyStyle($input, $output->section())`)

this PR allow a section to work like a normal output when using `write()` method