### PR TITLE
guard $argv + $token against null and causing exceptions

### DIFF
--- a/Input/ArgvInput.php
+++ b/Input/ArgvInput.php
@@ -48,9 +48,7 @@ class ArgvInput extends Input
      */
     public function __construct(array $argv = null, InputDefinition $definition = null)
     {
-        if (null === $argv) {
-            $argv = $_SERVER['argv'];
-        }
+        $argv = $argv ?? $_SERVER['argv'] ?? [];
 
         // strip the application name
         array_shift($argv);


### PR DESCRIPTION
This helps prevent an exception is has no relation to the actual offending code. See https://github.com/symfony/symfony/issues/38105