### PR TITLE
A regulation on helper.

### DIFF
--- a/Helper/Helper.php
+++ b/Helper/Helper.php
@@ -25,7 +25,7 @@ abstract class Helper implements HelperInterface
     /**
      * {@inheritdoc}
      */
-    public function setHelperSet(HelperSet $helperSet = null)
+    public function setHelperSet(HelperSet $helperSet)
     {
         $this->helperSet = $helperSet;
     }

--- a/Helper/HelperInterface.php
+++ b/Helper/HelperInterface.php
@@ -21,7 +21,7 @@ interface HelperInterface
     /**
      * Sets the helper set associated with this helper.
      */
-    public function setHelperSet(HelperSet $helperSet = null);
+    public function setHelperSet(HelperSet $helperSet);
 
     /**
      * Gets the helper set associated with this helper.


### PR DESCRIPTION
There is no need to report the helper twice that the default is blank. The compiler will understand this as it is already null defined. It is sufficient to specify it in the variable.