### PR TITLE
Extracting ProgressBar's format's magic strings into const

### DIFF
--- a/Helper/ProgressBar.php
+++ b/Helper/ProgressBar.php
@@ -26,6 +26,18 @@ use Symfony\Component\Console\Terminal;
  */
 final class ProgressBar
 {
+    public const VERY_VERBOSE = 'very_verbose';
+    public const VERY_VERBOSE_NOMAX = 'very_verbose_nomax';
+    public const VERBOSE_NOMAX = 'verbose_nomax';
+    public const VERBOSE = 'verbose';
+    public const DEBUG = 'debug';
+    public const DEBUG_NOMAX = 'debug_nomax';
+    public const NORMAL_NOMAX = 'normal_nomax';
+    public const NORMAL = 'normal';
+    public const VERBOSE_NO_ANSI = 'verbose_no_ansi';
+    public const VERY_VERBOSE_NO_ANSI = 'very_verbose_no_ansi';
+    public const NORMAL_NO_ANSI = 'normal_no_ansi';
+
     private $barWidth = 28;
     private $barChar;
     private $emptyBarChar = '-';
@@ -489,13 +501,13 @@ final class ProgressBar
         switch ($this->output->getVerbosity()) {
             // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
             case OutputInterface::VERBOSITY_VERBOSE:
-                return $this->max ? 'verbose' : 'verbose_nomax';
+                return $this->max ? self::VERBOSE : self::VERBOSE_NOMAX;
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
-                return $this->max ? 'very_verbose' : 'very_verbose_nomax';
+                return $this->max ? self::VERY_VERBOSE : self::VERY_VERBOSE_NOMAX;
             case OutputInterface::VERBOSITY_DEBUG:
-                return $this->max ? 'debug' : 'debug_nomax';
+                return $this->max ? self::DEBUG : self::DEBUG_NOMAX;
             default:
-                return $this->max ? 'normal' : 'normal_nomax';
+                return $this->max ? self::NORMAL : self::NORMAL_NOMAX;
         }
     }
 
@@ -547,17 +559,17 @@ final class ProgressBar
     private static function initFormats(): array
     {
         return [
-            'normal' => ' %current%/%max% [%bar%] %percent:3s%%',
-            'normal_nomax' => ' %current% [%bar%]',
+            self::NORMAL => ' %current%/%max% [%bar%] %percent:3s%%',
+            self::NORMAL_NOMAX => ' %current% [%bar%]',
 
-            'verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
-            'verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            self::VERBOSE => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
+            self::VERBOSE_NOMAX => ' %current% [%bar%] %elapsed:6s%',
 
-            'very_verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
-            'very_verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            self::VERY_VERBOSE => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
+            self::VERY_VERBOSE_NOMAX => ' %current% [%bar%] %elapsed:6s%',
 
-            'debug' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
-            'debug_nomax' => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
+            self::DEBUG => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
+            self::DEBUG_NOMAX => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
         ];
     }
 

--- a/Helper/ProgressIndicator.php
+++ b/Helper/ProgressIndicator.php
@@ -193,12 +193,12 @@ class ProgressIndicator
         switch ($this->output->getVerbosity()) {
             // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
             case OutputInterface::VERBOSITY_VERBOSE:
-                return $this->output->isDecorated() ? 'verbose' : 'verbose_no_ansi';
+                return $this->output->isDecorated() ? ProgressBar::VERBOSE : ProgressBar::VERBOSE_NO_ANSI;
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
             case OutputInterface::VERBOSITY_DEBUG:
-                return $this->output->isDecorated() ? 'very_verbose' : 'very_verbose_no_ansi';
+                return $this->output->isDecorated() ? ProgressBar::VERY_VERBOSE : ProgressBar::VERY_VERBOSE_NO_ANSI;
             default:
-                return $this->output->isDecorated() ? 'normal' : 'normal_no_ansi';
+                return $this->output->isDecorated() ? ProgressBar::NORMAL : ProgressBar::NORMAL_NO_ANSI;
         }
     }
 
@@ -241,14 +241,14 @@ class ProgressIndicator
     private static function initFormats(): array
     {
         return [
-            'normal' => ' %indicator% %message%',
-            'normal_no_ansi' => ' %message%',
+            ProgressBar::NORMAL => ' %indicator% %message%',
+            ProgressBar::NORMAL_NO_ANSI => ' %message%',
 
-            'verbose' => ' %indicator% %message% (%elapsed:6s%)',
-            'verbose_no_ansi' => ' %message% (%elapsed:6s%)',
+            ProgressBar::VERBOSE => ' %indicator% %message% (%elapsed:6s%)',
+            ProgressBar::VERBOSE_NO_ANSI => ' %message% (%elapsed:6s%)',
 
-            'very_verbose' => ' %indicator% %message% (%elapsed:6s%, %memory:6s%)',
-            'very_verbose_no_ansi' => ' %message% (%elapsed:6s%, %memory:6s%)',
+            ProgressBar::VERY_VERBOSE => ' %indicator% %message% (%elapsed:6s%, %memory:6s%)',
+            ProgressBar::VERY_VERBOSE_NO_ANSI => ' %message% (%elapsed:6s%, %memory:6s%)',
         ];
     }
 }

--- a/Tests/Helper/ProgressBarTest.php
+++ b/Tests/Helper/ProgressBarTest.php
@@ -865,10 +865,10 @@ class ProgressBarTest extends TestCase
     public function provideFormat(): array
     {
         return [
-            ['normal'],
-            ['verbose'],
-            ['very_verbose'],
-            ['debug'],
+            [ProgressBar::NORMAL],
+            [ProgressBar::VERBOSE],
+            [ProgressBar::VERY_VERBOSE],
+            [ProgressBar::DEBUG],
         ];
     }
 

--- a/Tests/Helper/ProgressIndicatorTest.php
+++ b/Tests/Helper/ProgressIndicatorTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\ProgressIndicator;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -152,10 +153,10 @@ class ProgressIndicatorTest extends TestCase
     public function provideFormat(): array
     {
         return [
-            ['normal'],
-            ['verbose'],
-            ['very_verbose'],
-            ['debug'],
+            [ProgressBar::NORMAL],
+            [ProgressBar::VERBOSE],
+            [ProgressBar::VERY_VERBOSE],
+            [ProgressBar::DEBUG],
         ];
     }
 


### PR DESCRIPTION
The existence of these magic string is propagating outside the project on the user land while constructing a command:
```php
$bar->setFormat('very_verbose');
```

Objective is to provide reusability and resilience to miss naming:
```php
$bar->setFormat(ProgressBar::VERBOSE);
```