### PR TITLE
Update command.php with php 7.4 typed properties

### DIFF
--- a/Command/Command.php
+++ b/Command/Command.php
@@ -37,12 +37,12 @@ class Command
     /**
      * @var string|null The default command name
      */
-    protected static $defaultName;
+    protected static ?string $defaultName;
 
     /**
      * @var string|null The default command description
      */
-    protected static $defaultDescription;
+    protected static ?string $defaultDescription;
 
     private $application;
     private $name;


### PR DESCRIPTION
As $defaultDescription and $defaultName are protected, they are overwritten in child classes. IDEs will tag some "Missing property's type declaration" and it will not be possible to add the property as it must remain the same declaration