### PR TITLE
Correctly wrap lines with decorated text.

### DIFF
--- a/Style/SymfonyStyle.php
+++ b/Style/SymfonyStyle.php
@@ -476,7 +476,9 @@ class SymfonyStyle extends OutputStyle
                 $message = OutputFormatter::escape($message);
             }
 
-            $lines = array_merge($lines, explode(\PHP_EOL, wordwrap($message, $this->lineLength - $prefixLength - $indentLength, \PHP_EOL, true)));
+            $undecorated_line_length = Helper::strlenWithoutDecoration($this->getFormatter(), $message);
+            $decorated_line_length = Helper::strlen($message);
+            $decoration_length = $decorated_line_length - $undecorated_line_length;
 
             if (\count($messages) > 1 && $key < \count($messages) - 1) {
                 $lines[] = '';


### PR DESCRIPTION
Currently, if you write a message to the console via block() and that message contains decorated text, the line will be wrapped too early. This is because the decoration tags are calculated as part of the line length.

This PR resolves that issue by accounting for the "decoration length" when wrapping the line.