### PR TITLE
Invert change from ansi negatable

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -1040,7 +1040,8 @@ class Application implements ResetInterface
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
-            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', false),
+            new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
+            new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
         ]);
     }


### PR DESCRIPTION
In https://github.com/symfony/console/blob/5.3/Input/InputDefinition.php#L255 there is no a check if a negatable exists. 
This means I can no longer add the no-ansi as an option. Reverting makes it possible to add the no-ansi again and use it in my command.