### PR TITLE
Readd missing php-doc parameter for constructor

### DIFF
--- a/Input/InputOption.php
+++ b/Input/InputOption.php
@@ -48,9 +48,11 @@ class InputOption
     private $description;
 
     /**
-     * @param string|array|null                $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                         $mode     The option mode: One of the VALUE_* constants
-     * @param string|bool|int|float|array|null $default  The default value (must be null for self::VALUE_NONE)
+     * @param string                           $name        The option name
+     * @param string|array|null                $shortcut.   The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                         $mode        The option mode: One of the VALUE_* constants
+     * @param string                           $description A description text
+     * @param string|bool|int|float|array|null $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */


### PR DESCRIPTION
partly revert the php constroctur php doc (readd missing php-doc for $name and $description) even if they not that meaningfull

This is needed as Magento2 uses this library and needs all php-doc parameter for interception compilation. if there are any missing parameters (in this case $name and $description) break compile step as the parameters are missmatching the actual parameters:

![image](https://user-images.githubusercontent.com/2969243/127111367-457af087-e990-4b54-9012-eaade8eb201b.png)

(AbstractConfigOption extends InputOption)