### PR TITLE
Update InputOption.php

### DIFF
--- a/Input/InputOption.php
+++ b/Input/InputOption.php
@@ -53,8 +53,10 @@ class InputOption
     private $description;
 
     /**
+     * @param string                           $name     The option name
      * @param string|array|null                $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int|null                         $mode     The option mode: One of the VALUE_* constants
+     * @param string                           $description A description text
      * @param string|bool|int|float|array|null $default  The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible


### PR DESCRIPTION
Hi, there is missed $name and $description params comment in InputOpion __construct, because of that magneto 2 code generator fails to generate code because of parameters type inconsistency. I see that at leas in version v4.4.24 comment was in place.