### PR TITLE
Fix IteratorAggregate return type on HelperSet, fatal error with PHP 8.1

### DIFF
--- a/Helper/HelperSet.php
+++ b/Helper/HelperSet.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Helper;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Traversable;
 
 /**
  * HelperSet represents a set of helpers to be used with a command.
@@ -91,7 +92,7 @@ class HelperSet implements \IteratorAggregate
     /**
      * @return Helper[]
      */
-    public function getIterator()
+    public function getIterator() : Traversable
     {
         return new \ArrayIterator($this->helpers);
     }


### PR DESCRIPTION
PHP 8.1 - Beta1

Fatal error: During inheritance of IteratorAggregate: Uncaught Return type of Symfony\Component\Console\Helper\HelperSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to hould be used to temporarily suppress the notice