### PR TITLE
Fix completion script affecting $IFS

### DIFF
--- a/Resources/completion.bash
+++ b/Resources/completion.bash
@@ -6,8 +6,8 @@
 # https://symfony.com/doc/current/contributing/code/license.html
 
 _sf_{{ COMMAND_NAME }}() {
-    # Use newline as only separator to allow space in completion values
-    IFS=$'\n'
+    # Allow certain characters to not separate completion words
+    COMP_WORDBREAKS=${COMP_WORDBREAKS//[:=@]}
     local sf_cmd="${COMP_WORDS[0]}"
 
     # for an alias, get the real script behind it


### PR DESCRIPTION
Set `COMP_WORDBREAKS` instead of `IFS`.

More in-depth explanation:

`IFS` affects other things not related to programmable completion, such as how the shell breaks up argument lists.

For example, by default this splits the unquoted variable as-expected:
```sh
OPTION_LIST='foo bar'
for OPT in $OPTION_LIST; do printf '%s\n' "$OPT"; done
> foo
> bar
```

Changing IFS makes the variable not split as expected, printing all on one line:
```sh
IFS=$'\n'
for OPT in $OPTION_LIST; do printf '%s\n' "$OPT"; done
> foo bar
```

This PR changes it to use `$COMP_WORDBREAKS` which specifically affects how programmable completion works, instead of affecting and effectively poisoning how the user's shell works.