### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -1209,7 +1209,7 @@ class Application implements ResetInterface
         // additionally, array_slice() is not enough as some character has doubled width.
         // we need a function to split string not by character count but by string width
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
-            return str_split($string, $width);
+            return mb_str_split($string, $width);
         }
 
         $utf8String = mb_convert_encoding($string, 'utf8', $encoding);

--- a/Helper/Table.php
+++ b/Helper/Table.php
@@ -804,7 +804,7 @@ class Table
                             $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
                             $textLength = Helper::width($textContent);
                             if ($textLength > 0) {
-                                $contentColumns = str_split($textContent, ceil($textLength / $cell->getColspan()));
+                                $contentColumns = mb_str_split($textContent, ceil($textLength / $cell->getColspan()));
                                 foreach ($contentColumns as $position => $content) {
                                     $row[$i + $position] = $content;
                                 }


### PR DESCRIPTION
In PHP 8.2, the str_split function will returns empty arrays for empty strings.
See: https://php.watch/versions/8.2/str_split-empty-string-empty-array

We can use mb_str_split() instead