### PR TITLE
Add missing console/tester assertion

### DIFF
--- a/Tester/Constraint/CommandIsFaulty.php
+++ b/Tester/Constraint/CommandIsFaulty.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Raphael Stolt <raphael.stolt@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Console\Command\Command;
+
+final class CommandIsFaulty extends Constraint
+{
+    public function toString(): string
+    {
+        return 'is faulty';
+    }
+
+    protected function matches($other): bool
+    {
+        return Command::FAILURE === $other || Command::INVALID === $other;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the command '.$this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        $mapping = [
+            Command::SUCCESS => 'Command was successful.'
+        ];
+
+        return $mapping[$other] ?? sprintf('Command returned exit status %d.', $other);
+    }
+}

--- a/Tester/TesterTrait.php
+++ b/Tester/TesterTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\Constraint\CommandIsFaulty;
 use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 
 /**
@@ -102,6 +103,11 @@ trait TesterTrait
     public function assertCommandIsSuccessful(string $message = ''): void
     {
         Assert::assertThat($this->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    public function assertCommandIsFaulty(string $message = ''): void
+    {
+        Assert::assertThat($this->statusCode, new CommandIsFaulty(), $message);
     }
 
     /**

--- a/Tests/Tester/Constraint/CommandIsFaultyTest.php
+++ b/Tests/Tester/Constraint/CommandIsFaultyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Raphael Stolt <raphael.stolt@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Tester\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestFailure;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\Constraint\CommandIsFaulty;
+
+final class CommandIsFaultyTest extends TestCase
+{
+    public function testConstraint()
+    {
+        $constraint = new CommandIsFaulty();
+
+        $this->assertFalse($constraint->evaluate(Command::SUCCESS, '', true));
+        $this->assertTrue($constraint->evaluate(Command::FAILURE, '', true));
+        $this->assertTrue($constraint->evaluate(Command::INVALID, '', true));
+    }
+
+    public function testSuccessfulCommand()
+    {
+        $constraint = new CommandIsFaulty();
+
+        try {
+            $constraint->evaluate(Command::SUCCESS);
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('Failed asserting that the command is faulty.', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}


### PR DESCRIPTION
Adds the missing `assertCommandIsFaulty` custom PHPUnit assertion.